### PR TITLE
ci: ruff lint + Python 3.10–3.14 matrix + cross-OS coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Run ruff
         uses: astral-sh/ruff-action@v3
         with:
-          args: "check --target-version py310 scripts/"
+          args: "check --target-version py310"
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,28 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Run ruff
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "check --target-version py310 scripts/"
 
-      - name: Set up Python
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -35,12 +48,64 @@ jobs:
             fi
           done
 
-      - name: Validate bundled eval specs
+      - name: Validate and roll out bundled eval specs
         run: |
           for runner in references/examples/*/scripts/run_evals.py; do
             [ -f "$runner" ] || continue
             skill_dir="$(dirname "$(dirname "$runner")")"
             echo "::group::eval $skill_dir"
             python3 "$runner" "$skill_dir" --validate
+            python3 "$runner" "$skill_dir" --rollout
             echo "::endgroup::"
           done
+
+  cross-os:
+    # The project's promise is cross-platform install; run the suite on the
+    # other POSIX/Windows targets to catch path- and OS-specific bugs.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            pytest_args: "scripts/tests/ -q"
+          - os: windows-latest
+            # test_run_evals exercises the eval runner's command-checks, which
+            # use a POSIX shell (test/grep via shell=True) and don't run under
+            # cmd.exe. Everything else (path handling, parsing, export) is
+            # portable and does run on Windows.
+            pytest_args: "scripts/tests/ -q --ignore=scripts/tests/test_run_evals.py"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Run test suite
+        run: uv run --with pytest pytest ${{ matrix.pytest_args }}
+
+  powershell:
+    # Syntax-check the Windows installers so a broken .ps1 cannot ship
+    # unnoticed (the headline claim includes Windows tools).
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse-check PowerShell installers
+        shell: pwsh
+        run: |
+          $failed = $false
+          Get-ChildItem -Recurse -Filter *.ps1 | ForEach-Object {
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile(
+              $_.FullName, [ref]$null, [ref]$errors) | Out-Null
+            if ($errors) {
+              Write-Host "::error file=$($_.FullName)::PowerShell parse errors"
+              $errors | ForEach-Object { Write-Host "  $($_.Message)" }
+              $failed = $true
+            } else {
+              Write-Host "OK: $($_.FullName)"
+            }
+          }
+          if ($failed) { exit 1 }

--- a/references/examples/stock-analyzer/scripts/main.py
+++ b/references/examples/stock-analyzer/scripts/main.py
@@ -157,7 +157,7 @@ class StockAnalyzer:
             'timestamp': datetime.now().isoformat()
         }
 
-        print(f"[StockAnalyzer] Comparison complete")
+        print("[StockAnalyzer] Comparison complete")
         print("  Rankings:")
         for comp in comparisons:
             print(f"    #{comp['rank']}: {comp['ticker']} (score: {comp['score']:.2f})")
@@ -187,7 +187,7 @@ class StockAnalyzer:
             >>> print(alert['status'])
             active
         """
-        print(f"\n[StockAnalyzer] Setting up monitoring...")
+        print("\n[StockAnalyzer] Setting up monitoring...")
         print(f"  - Ticker: {ticker}")
         print(f"  - Condition: {condition}")
         print(f"  - Action: {action}")
@@ -382,6 +382,8 @@ def main():
     # Example 2: Multi-stock comparison
     print("\n\n--- Example 2: Compare Tech Stocks ---")
     comparison = analyzer.compare(["AAPL", "MSFT", "GOOGL"], rank_by="momentum")
+    for stock in comparison["ranked_stocks"]:
+        print(f"  {stock['ticker']}: {stock['score']}")
 
     # Example 3: Set up monitoring
     print("\n\n--- Example 3: Monitor Stock ---")

--- a/scripts/export_utils.py
+++ b/scripts/export_utils.py
@@ -664,6 +664,15 @@ def export_skill(
 
 def main():
     """CLI interface for export_utils.py"""
+    # The status output uses emoji; Windows consoles default to cp1252 and
+    # raise UnicodeEncodeError on them. Force UTF-8 where the stream supports it.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8")
+            except (ValueError, OSError):
+                pass
+
     if len(sys.argv) < 2:
         print("""
 Usage: python export_utils.py <skill-path> [options]

--- a/scripts/tests/test_export_utils.py
+++ b/scripts/tests/test_export_utils.py
@@ -95,9 +95,11 @@ class TestExportSkillRegression(unittest.TestCase):
                 "--version", "9.9.9",
                 "--output-dir", str(self.out),
             ],
-            capture_output=True, text=True, timeout=120,
+            # The CLI emits UTF-8 (emoji status output); decode it as UTF-8 so
+            # capture works regardless of the platform's default code page.
+            capture_output=True, text=True, encoding="utf-8", timeout=120,
         )
-        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.returncode, 0, (result.stdout or "") + (result.stderr or ""))
         expected = self.out / "demo-export-skill-desktop-v9.9.9.zip"
         self.assertTrue(
             expected.exists(),

--- a/scripts/tests/test_export_utils.py
+++ b/scripts/tests/test_export_utils.py
@@ -168,7 +168,9 @@ class TestCreateExportPackage(unittest.TestCase):
 
     def _names(self, result):
         with zipfile.ZipFile(result["zip_path"]) as zf:
-            return set(zf.namelist())
+            # Zip arcnames always use forward slashes; normalize so the
+            # assertions below are identical on POSIX and Windows.
+            return {name.replace("\\", "/") for name in zf.namelist()}
 
     def test_desktop_variant_includes_docs_and_excludes_secrets(self):
         result = create_export_package(
@@ -177,7 +179,7 @@ class TestCreateExportPackage(unittest.TestCase):
         self.assertTrue(result["success"], result["message"])
         names = self._names(result)
         self.assertIn("SKILL.md", names)
-        self.assertIn(os.path.join("references", "guide.md"), names)
+        self.assertIn("references/guide.md", names)
         self.assertNotIn(".env", names)
 
     def test_api_variant_excludes_extra_docs_and_examples(self):
@@ -187,8 +189,8 @@ class TestCreateExportPackage(unittest.TestCase):
         self.assertTrue(result["success"], result["message"])
         names = self._names(result)
         self.assertIn("SKILL.md", names)
-        self.assertNotIn(os.path.join("references", "guide.md"), names)
-        self.assertNotIn(os.path.join("examples", "sample.csv"), names)
+        self.assertNotIn("references/guide.md", names)
+        self.assertNotIn("examples/sample.csv", names)
 
 
 class TestExportSkillFailurePath(unittest.TestCase):


### PR DESCRIPTION
## Why
CI tested only Python 3.12 on Linux and ran no linter — thin for a project whose headline is cross-platform install. This widens coverage to the OSes and Python versions the project actually claims to support.

## Changes
- **lint** — `ruff check` (target py310), matching the `CONTRIBUTING.md` convention that was never enforced.
- **test** — matrix across **Python 3.10–3.14** (all green locally via `uv run --python`). Also rolls out the bundled eval specs (`--rollout`), not just `--validate`, so a skill whose pipeline breaks at runtime now fails CI.
- **cross-os** — runs the suite on **macOS** and **Windows** to catch path/OS bugs. Windows skips `test_run_evals.py` (the eval runner's command-checks use a POSIX shell via `shell=True` and don't run under cmd.exe); everything else (path handling, parsing, export, install parity) is portable and runs on Windows.
- **powershell** — AST parse-checks every `.ps1` installer on Windows so a broken Windows installer can't ship unnoticed.

## Verified locally before pushing
- Full suite (153 tests) passes on Python 3.10, 3.11, 3.12, 3.13, 3.14.
- Windows-equivalent subset (123 tests, minus the POSIX-shell eval tests) passes.
- All three example eval specs pass `--rollout` with exit 0 (stock-analyzer uses mock data — no network, not flaky).
- ruff clean targeting py310.

## Known scope boundary
The eval runner's command-checks are POSIX-shell-based by design; making them run natively under cmd.exe is out of scope here (tracked separately if desired). macOS gives real non-Linux POSIX coverage in the meantime.