### PR TITLE
Resolve deferred flaw-fix issues (#10, #11, #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ python3 scripts/staleness_check.py ./my-skill/
 python3 scripts/staleness_check.py ./my-skill/ --check-deps --check-drift
 ```
 
-Skills that fail validation cannot be published. Skills with high-severity security issues are blocked.
+Skills that fail validation cannot be published. On publish, high-severity security issues block the skill (override with `--force`). On export, findings are reported but don't block by default — pass `--strict` to fail the export on any high-severity issue.
 
 ---
 
@@ -548,6 +548,7 @@ python3 scripts/skill_registry.py list                                # Browse a
 python3 scripts/skill_registry.py search "query"                     # Search skills
 python3 scripts/skill_registry.py info skill-name                    # Skill details
 python3 scripts/skill_registry.py install skill-name                 # Install a skill
+python3 scripts/skill_registry.py install skill-name --author alice  # Disambiguate a shared name
 python3 scripts/skill_registry.py remove skill-name --force          # Remove a skill
 python3 scripts/skill_registry.py stale                              # Report stale skills
 python3 scripts/skill_registry.py stale --json                       # Machine-readable output
@@ -607,6 +608,7 @@ python3 scripts/staleness_check.py ./skill/ --json               # Machine-reada
 ```bash
 python3 scripts/export_utils.py ./skill/ --variant desktop    # For Claude Desktop
 python3 scripts/export_utils.py ./skill/ --variant api        # For Claude API
+python3 scripts/export_utils.py ./skill/ --strict             # Block export on high-severity findings
 ```
 
 All commands use exit code `0` for success, `1` for errors. All support `--json` for CI/CD integration.

--- a/scripts/export_utils.py
+++ b/scripts/export_utils.py
@@ -545,7 +545,8 @@ def export_skill(
     skill_path: str,
     variants: List[str] = ['desktop', 'api'],
     version_override: str = None,
-    output_dir: str = None
+    output_dir: str = None,
+    strict: bool = False
 ) -> Dict:
     """
     Main export function - validates, packages, and generates guides.
@@ -555,6 +556,9 @@ def export_skill(
         variants: List of variants to create ('desktop', 'api', or both)
         version_override: User-specified version (optional)
         output_dir: Where to save exports (default: exports/ in parent dir)
+        strict: If True, block the export when the security scan reports any
+            high-severity issue. Default False keeps the report-don't-block
+            behavior (findings are printed but the export proceeds).
 
     Returns:
         Dict with export results
@@ -600,10 +604,31 @@ def export_skill(
                 import json as _json
                 try:
                     sec_result = _json.loads(result.stdout)
-                    if sec_result.get('issues'):
-                        print(f"⚠️  Security issues found: {len(sec_result['issues'])}")
-                        for issue in sec_result['issues'][:5]:
+                    issues = sec_result.get('issues', [])
+                    if issues:
+                        print(f"⚠️  Security issues found: {len(issues)}")
+                        for issue in issues[:5]:
                             print(f"   - [{issue.get('severity', 'unknown')}] {issue.get('description', '')}")
+                        high_issues = [i for i in issues if i.get('severity') == 'high']
+                        if strict and high_issues:
+                            print(
+                                f"❌ Strict mode: blocking export on "
+                                f"{len(high_issues)} high-severity security issue(s)."
+                            )
+                            return {
+                                'success': False,
+                                'message': (
+                                    f"Security scan failed (strict mode): "
+                                    f"{len(high_issues)} high-severity issue(s)"
+                                ),
+                                'issues': [
+                                    f"[{i.get('severity')}] "
+                                    f"{i.get('file', '')}"
+                                    f"{':' + str(i['line']) if i.get('line') else ''}: "
+                                    f"{i.get('description', '')}"
+                                    for i in high_issues
+                                ],
+                            }
                 except (ValueError, KeyError):
                     pass
             else:
@@ -684,12 +709,15 @@ Options:
   --variant VARIANT       Export variant: desktop, api, or both (default: both)
   --version VERSION       Override version (default: auto-detect)
   --output-dir DIR        Output directory (default: exports/)
+  --strict                Block the export if the security scan reports any
+                          high-severity issue (default: report but don't block)
 
 Examples:
   python export_utils.py ./my-skill
   python export_utils.py ./my-skill --variant desktop
   python export_utils.py ./my-skill --version 2.0.1
   python export_utils.py ./my-skill --variant api --output-dir ./dist
+  python export_utils.py ./my-skill --strict
 """)
         sys.exit(1)
 
@@ -699,6 +727,7 @@ Examples:
     variants = ['desktop', 'api']  # default: both
     version_override = None
     output_dir = None
+    strict = False
 
     i = 2
     while i < len(sys.argv):
@@ -715,13 +744,19 @@ Examples:
         elif sys.argv[i] == '--output-dir':
             output_dir = sys.argv[i + 1]
             i += 2
+        elif sys.argv[i] == '--strict':
+            strict = True
+            i += 1
         else:
             print(f"Unknown option: {sys.argv[i]}")
             sys.exit(1)
 
     # Run export
     print(f"\n🚀 Exporting skill: {os.path.basename(skill_path)}\n")
-    results = export_skill(skill_path, variants, version_override=version_override, output_dir=output_dir)
+    results = export_skill(
+        skill_path, variants,
+        version_override=version_override, output_dir=output_dir, strict=strict,
+    )
 
     # Print summary
     print(f"\n{'='*60}")

--- a/scripts/security_scan.py
+++ b/scripts/security_scan.py
@@ -68,6 +68,47 @@ API_KEY_PATTERNS: list[tuple[str, re.Pattern, str, str]] = [
         "high",
     ),
     (
+        "Anthropic API Key",
+        # Listed before the OpenAI "sk-" pattern; the hyphens in "sk-ant-"
+        # stop the OpenAI regex from matching, so order is for clarity only.
+        re.compile(r"sk-ant-[a-zA-Z0-9_\-]{20,}"),
+        "Hardcoded Anthropic API key detected",
+        "high",
+    ),
+    (
+        "Stripe Secret Key",
+        re.compile(r"[sr]k_live_[0-9a-zA-Z]{16,}"),
+        "Hardcoded Stripe live secret/restricted key detected",
+        "high",
+    ),
+    (
+        "npm Access Token",
+        re.compile(r"npm_[A-Za-z0-9]{36}"),
+        "Hardcoded npm access token detected",
+        "high",
+    ),
+    (
+        "Google API Key",
+        re.compile(r"AIza[0-9A-Za-z_\-]{35}"),
+        "Hardcoded Google API key detected",
+        "high",
+    ),
+    (
+        "Hugging Face Token",
+        re.compile(r"hf_[a-zA-Z0-9]{34,}"),
+        "Hardcoded Hugging Face access token detected",
+        "high",
+    ),
+    (
+        "JSON Web Token",
+        # Three base64url segments; the first two header/payload parts of a
+        # JWT both start with "eyJ" (base64 of '{"'). Medium severity: a JWT
+        # is not always a long-lived secret and can appear legitimately in docs.
+        re.compile(r"eyJ[a-zA-Z0-9_\-]+\.eyJ[a-zA-Z0-9_\-]+\.[a-zA-Z0-9_\-]+"),
+        "Possible hardcoded JSON Web Token (JWT) detected",
+        "medium",
+    ),
+    (
         "Generic Secret",
         re.compile(
             r"""(api[_\-]?key|secret|token|password)\s*[:=]\s*["'][^"']{8,}["']""",

--- a/scripts/skill_registry.py
+++ b/scripts/skill_registry.py
@@ -25,7 +25,7 @@ import json
 import re
 import shutil
 import sys
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 # --- Import sibling scripts ---
@@ -70,6 +70,75 @@ STOP_WORDS = {
 }
 
 MIN_TAG_LENGTH = 3
+
+
+# --- Namespacing & date parsing helpers ---
+
+def _slug(value: str) -> str:
+    """Return a filesystem-safe slug for an author/namespace path segment."""
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip().lower()).strip("-")
+    return slug or "unknown"
+
+
+def skill_storage_path(name: str, author: str) -> str:
+    """
+    Relative registry path for a skill's files, namespaced by author.
+
+    A skill with an author is stored under ``skills/<author-slug>/<name>`` so
+    two authors can publish the same skill name without clobbering each other's
+    files. Authorless skills keep the legacy flat ``skills/<name>`` layout for
+    backward compatibility with registries created before namespacing.
+    """
+    if author:
+        return f"skills/{_slug(author)}/{name}"
+    return f"skills/{name}"
+
+
+def resolve_skill_entry(
+    data: dict, name: str, author: str | None = None
+) -> tuple[dict | None, str | None]:
+    """
+    Find a single skill entry by name, disambiguating by author when needed.
+
+    Returns ``(entry, None)`` on a unique match, or ``(None, error_message)``
+    when the skill is missing or the name is shared by multiple authors and no
+    ``author`` filter was supplied.
+    """
+    matches = [s for s in data["skills"] if s.get("name") == name]
+    if author is not None:
+        matches = [s for s in matches if s.get("author", "") == author]
+
+    if not matches:
+        return None, f"skill '{name}' not found in registry."
+
+    authors = sorted({s.get("author", "") for s in matches})
+    if len(authors) > 1:
+        listed = ", ".join(a or "(no author)" for a in authors)
+        return None, (
+            f"skill '{name}' is published by multiple authors ({listed}); "
+            f"use --author to disambiguate."
+        )
+
+    # Unique (name, author); preserve first-published selection across versions.
+    return matches[0], None
+
+
+def parse_iso_date(value: str) -> date | None:
+    """
+    Parse an ISO date or timestamp string into a ``date``.
+
+    Accepts both plain dates ("2026-06-13") and full ISO timestamps
+    ("2026-06-13T12:00:00+00:00"). Returns None for empty or unparseable input.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value).date()
+    except ValueError:
+        try:
+            return date.fromisoformat(value[:10])
+        except ValueError:
+            return None
 
 
 # --- Registry I/O ---
@@ -326,24 +395,38 @@ def cmd_publish(args: argparse.Namespace) -> None:
     if not tags:
         tags = auto_extract_tags(metadata["description"])
 
-    # Step 5: Check duplicates
+    author = metadata["author"]
+
+    # Step 5: Check duplicates. Identity is (name, author, version) so two
+    # authors can publish the same skill name without colliding.
     data = load_registry(registry_path)
+
+    def _same_skill(s: dict) -> bool:
+        return (
+            s["name"] == name
+            and s.get("author", "") == author
+            and s["version"] == version
+        )
+
     for existing in data["skills"]:
-        if existing["name"] == name and existing["version"] == version:
+        if _same_skill(existing):
             if not args.force:
+                who = f" by '{author}'" if author else ""
                 print(
-                    f"Error: skill '{name}' version '{version}' already exists in registry.",
+                    f"Error: skill '{name}' version '{version}'{who} already exists in registry.",
                     file=sys.stderr,
                 )
                 print("Use --force to overwrite.", file=sys.stderr)
                 sys.exit(1)
             # Remove old entry if forcing
-            data["skills"] = [s for s in data["skills"] if not (s["name"] == name and s["version"] == version)]
+            data["skills"] = [s for s in data["skills"] if not _same_skill(s)]
 
-    # Step 6: Copy skill to registry
-    dest = registry_path / "skills" / name
+    # Step 6: Copy skill to registry (author-namespaced path)
+    rel_path = skill_storage_path(name, author)
+    dest = registry_path / rel_path
     if dest.exists():
         shutil.rmtree(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(skill_path, dest, ignore=COPY_IGNORE_PATTERNS)
 
     # Step 7: Add entry (including staleness metadata)
@@ -362,12 +445,12 @@ def cmd_publish(args: argparse.Namespace) -> None:
         "name": name,
         "description": metadata["description"],
         "version": version,
-        "author": metadata["author"],
+        "author": author,
         "license": metadata["license"],
         "tags": tags,
         "platforms": list(ALL_PLATFORMS),
         "published": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "path": f"skills/{name}",
+        "path": rel_path,
         "validation": {
             "valid": validation["valid"],
             "errors": len(validation["errors"]),
@@ -436,15 +519,10 @@ def cmd_install(args: argparse.Namespace) -> None:
     registry_path = Path(args.registry).resolve()
     data = load_registry(registry_path)
 
-    # Find skill
-    skill_entry = None
-    for skill in data["skills"]:
-        if skill["name"] == args.skill_name:
-            skill_entry = skill
-            break
-
+    # Find skill (disambiguating by author when the name is shared)
+    skill_entry, error = resolve_skill_entry(data, args.skill_name, getattr(args, "author", None))
     if skill_entry is None:
-        print(f"Error: skill '{args.skill_name}' not found in registry.", file=sys.stderr)
+        print(f"Error: {error}", file=sys.stderr)
         sys.exit(1)
 
     # Resolve platform
@@ -508,14 +586,9 @@ def cmd_info(args: argparse.Namespace) -> None:
     registry_path = Path(args.registry).resolve()
     data = load_registry(registry_path)
 
-    skill_entry = None
-    for skill in data["skills"]:
-        if skill["name"] == args.skill_name:
-            skill_entry = skill
-            break
-
+    skill_entry, error = resolve_skill_entry(data, args.skill_name, getattr(args, "author", None))
     if skill_entry is None:
-        print(f"Error: skill '{args.skill_name}' not found in registry.", file=sys.stderr)
+        print(f"Error: {error}", file=sys.stderr)
         sys.exit(1)
 
     if getattr(args, "json", False):
@@ -551,15 +624,10 @@ def cmd_remove(args: argparse.Namespace) -> None:
     registry_path = Path(args.registry).resolve()
     data = load_registry(registry_path)
 
-    # Find skill
-    skill_entry = None
-    for skill in data["skills"]:
-        if skill["name"] == args.skill_name:
-            skill_entry = skill
-            break
-
+    # Find skill (disambiguating by author when the name is shared)
+    skill_entry, error = resolve_skill_entry(data, args.skill_name, getattr(args, "author", None))
     if skill_entry is None:
-        print(f"Error: skill '{args.skill_name}' not found in registry.", file=sys.stderr)
+        print(f"Error: {error}", file=sys.stderr)
         sys.exit(1)
 
     if not args.force:
@@ -571,8 +639,12 @@ def cmd_remove(args: argparse.Namespace) -> None:
     if skill_dir.exists():
         shutil.rmtree(skill_dir)
 
-    # Remove entry
-    data["skills"] = [s for s in data["skills"] if s["name"] != args.skill_name]
+    # Remove only the resolved author's entries for this name (all versions).
+    target_author = skill_entry.get("author", "")
+    data["skills"] = [
+        s for s in data["skills"]
+        if not (s["name"] == args.skill_name and s.get("author", "") == target_author)
+    ]
     save_registry(registry_path, data)
 
     print(f"Removed '{args.skill_name}' from registry.")
@@ -580,7 +652,7 @@ def cmd_remove(args: argparse.Namespace) -> None:
 
 def cmd_stale(args: argparse.Namespace) -> None:
     """Report skills that are overdue for review."""
-    from datetime import date, timedelta
+    from datetime import timedelta
 
     registry_path = Path(args.registry).resolve()
     data = load_registry(registry_path)
@@ -595,32 +667,15 @@ def cmd_stale(args: argparse.Namespace) -> None:
         ref_date = None
         date_source = "none"
 
-        lr = staleness.get("last_reviewed", "")
-        cr = staleness.get("created", "")
-
-        if lr:
-            try:
-                parts = lr.split("-")
-                ref_date = date(int(parts[0]), int(parts[1]), int(parts[2]))
-                date_source = "last_reviewed"
-            except (ValueError, IndexError):
-                pass
-
-        if ref_date is None and cr:
-            try:
-                parts = cr.split("-")
-                ref_date = date(int(parts[0]), int(parts[1]), int(parts[2]))
-                date_source = "created"
-            except (ValueError, IndexError):
-                pass
-
-        if ref_date is None and published:
-            try:
-                parts = published[:10].split("-")
-                ref_date = date(int(parts[0]), int(parts[1]), int(parts[2]))
-                date_source = "published"
-            except (ValueError, IndexError):
-                pass
+        for value, source in (
+            (staleness.get("last_reviewed", ""), "last_reviewed"),
+            (staleness.get("created", ""), "created"),
+            (published, "published"),
+        ):
+            ref_date = parse_iso_date(value)
+            if ref_date is not None:
+                date_source = source
+                break
 
         interval = staleness.get("review_interval_days", DEFAULT_REVIEW_INTERVAL_DAYS)
         if not isinstance(interval, int):
@@ -734,6 +789,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_install = subparsers.add_parser("install", help="Install a skill from the registry")
     p_install.add_argument("skill_name", help="Name of the skill to install")
     _add_registry_arg(p_install)
+    p_install.add_argument("--author", help="Disambiguate when the name is shared by multiple authors")
     p_install.add_argument("--platform", choices=ALL_PLATFORMS, help="Target platform (auto-detected if omitted)")
     p_install.add_argument("--project", action="store_true", help="Install at project level instead of user level")
     p_install.add_argument("--force", action="store_true", help="Overwrite existing installation")
@@ -743,12 +799,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_info = subparsers.add_parser("info", help="Show detailed info about a skill")
     p_info.add_argument("skill_name", help="Name of the skill")
     _add_registry_arg(p_info)
+    p_info.add_argument("--author", help="Disambiguate when the name is shared by multiple authors")
     p_info.add_argument("--json", action="store_true", help="Output as JSON")
 
     # remove
     p_remove = subparsers.add_parser("remove", help="Remove a skill from the registry")
     p_remove.add_argument("skill_name", help="Name of the skill to remove")
     _add_registry_arg(p_remove)
+    p_remove.add_argument("--author", help="Disambiguate when the name is shared by multiple authors")
     p_remove.add_argument("--force", action="store_true", help="Confirm removal")
 
     # stale

--- a/scripts/tests/test_export_utils.py
+++ b/scripts/tests/test_export_utils.py
@@ -203,5 +203,58 @@ class TestExportSkillFailurePath(unittest.TestCase):
             self.assertTrue(results.get("issues"))
 
 
+class TestStrictSecurityFlag(unittest.TestCase):
+    """Issue #11: --strict blocks export on high-severity security findings."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self.skill = make_skill(self.base, "demo-strict-skill")
+        # A hardcoded GitHub PAT (built by concatenation so this test file
+        # never contains a contiguous token-shaped string) -> high severity.
+        token = "ghp_" + "a1B2" * 9
+        (self.skill / "scripts" / "leak.py").write_text(
+            f'TOKEN = "{token}"\n', encoding="utf-8"
+        )
+        self.out = self.base / "out"
+        self.out.mkdir()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_strict_blocks_export_on_high_severity(self):
+        results = export_skill(
+            str(self.skill), ["desktop"],
+            version_override="1.0.0", output_dir=str(self.out), strict=True,
+        )
+        self.assertFalse(results["success"], results)
+        self.assertTrue(results.get("issues"))
+        # No package should have been written when strict mode blocks.
+        self.assertEqual(list(self.out.iterdir()), [])
+
+    def test_default_does_not_block_on_high_severity(self):
+        results = export_skill(
+            str(self.skill), ["desktop"],
+            version_override="1.0.0", output_dir=str(self.out),
+        )
+        self.assertTrue(results["success"], results)
+        zip_path = Path(results["packages"]["desktop"]["zip_path"])
+        self.assertTrue(zip_path.exists())
+
+    def test_cli_strict_flag_blocks(self):
+        result = subprocess.run(
+            [
+                sys.executable, str(EXPORT_CLI), str(self.skill),
+                "--variant", "desktop",
+                "--version", "1.0.0",
+                "--output-dir", str(self.out),
+                "--strict",
+            ],
+            capture_output=True, text=True, encoding="utf-8", timeout=120,
+        )
+        self.assertEqual(result.returncode, 1, (result.stdout or "") + (result.stderr or ""))
+        self.assertEqual(list(self.out.iterdir()), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_security_scan.py
+++ b/scripts/tests/test_security_scan.py
@@ -57,5 +57,65 @@ class TestGitHubTokenDetection(unittest.TestCase):
             self.assertTrue(result["clean"], result["issues"])
 
 
+class TestModernTokenDetection(unittest.TestCase):
+    """Patterns added for issue #12: Stripe, npm, Google, Anthropic, HF, JWT."""
+
+    def _patterns_found(self, content):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = make_skill_with_content(Path(tmp), content)
+            result = security_scan(str(skill))
+            return {issue["pattern"] for issue in result["issues"]}
+
+    def test_anthropic_key_detected(self):
+        token = "sk-" + "ant-" + "api03-" + "Zz0" * 9  # 27 chars after sk-ant-
+        found = self._patterns_found(f'KEY = "{token}"\n')
+        self.assertIn("Anthropic API Key", found)
+
+    def test_stripe_live_key_detected(self):
+        token = "sk_" + "live_" + "4eC39Hq" * 4  # 28 chars after prefix
+        found = self._patterns_found(f'KEY = "{token}"\n')
+        self.assertIn("Stripe Secret Key", found)
+
+    def test_stripe_restricted_key_detected(self):
+        token = "rk_" + "live_" + "4eC39Hq" * 4
+        found = self._patterns_found(f'KEY = "{token}"\n')
+        self.assertIn("Stripe Secret Key", found)
+
+    def test_npm_token_detected(self):
+        token = "npm_" + "x9Y8z7w6" * 4 + "abcd"  # 36 chars after prefix
+        found = self._patterns_found(f'TOKEN = "{token}"\n')
+        self.assertIn("npm Access Token", found)
+
+    def test_google_api_key_detected(self):
+        token = "AIza" + "Sy0" * 11 + "ab"  # 35 chars after prefix
+        found = self._patterns_found(f'KEY = "{token}"\n')
+        self.assertIn("Google API Key", found)
+
+    def test_huggingface_token_detected(self):
+        token = "hf_" + "aBcDeFgHiJ" * 3 + "klmn"  # 34 chars after prefix
+        found = self._patterns_found(f'TOKEN = "{token}"\n')
+        self.assertIn("Hugging Face Token", found)
+
+    def test_jwt_detected(self):
+        header = "eyJ" + "abc012_-AB"
+        payload = "eyJ" + "def345_-CD"
+        signature = "Sig" + "nature9_-x"
+        token = header + "." + payload + "." + signature
+        found = self._patterns_found(f'JWT = "{token}"\n')
+        self.assertIn("JSON Web Token", found)
+
+    def test_modern_tokens_benign_content_clean(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill = make_skill_with_content(
+                Path(tmp),
+                'import os\n'
+                'STRIPE = os.environ["STRIPE_SECRET_KEY"]\n'
+                'ANTHROPIC = os.environ["ANTHROPIC_API_KEY"]\n'
+                'HF = os.getenv("HF_TOKEN")\n',
+            )
+            result = security_scan(str(skill))
+            self.assertTrue(result["clean"], result["issues"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_skill_registry.py
+++ b/scripts/tests/test_skill_registry.py
@@ -1,0 +1,335 @@
+"""Tests for scripts.skill_registry.
+
+Covers the gaps called out in issue #10:
+  * publish: validation gating + (name, author, version) duplicate detection
+  * install: platform/path resolution + author disambiguation
+  * search
+  * stale: ISO date parsing (datetime.fromisoformat, not naive slicing)
+  * author/namespace isolation so two authors can share a skill name
+
+The registry is created under a TemporaryDirectory and project-level installs
+chdir into the temp dir, so nothing touches the real home or repo tree.
+"""
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import unittest
+from datetime import date, timedelta
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import skill_registry as reg  # noqa: E402
+
+
+def make_skill(base: Path, name: str, author: str = "alice", version: str = "1.0.0") -> Path:
+    """Create a minimal skill directory that passes validate.validate_skill.
+
+    validate_skill requires the directory basename to equal the ``name`` field,
+    so the leaf is exactly ``name`` and a per-author parent keeps two authors'
+    sources for the same skill name from colliding on disk.
+    """
+    skill = base / f"src-{author}" / name
+    (skill / "scripts").mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        f"""---
+name: {name}
+description: >-
+  Demo skill {name} used by skill_registry tests for coverage.
+license: MIT
+metadata:
+  author: {author}
+  version: {version}
+---
+# /{name}
+
+Demo body.
+""",
+        encoding="utf-8",
+    )
+    (skill / "scripts" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+    return skill
+
+
+def init_registry(base: Path) -> Path:
+    registry = base / "registry"
+    args = argparse.Namespace(registry=str(registry), name="Test Registry")
+    reg.cmd_init(args)
+    return registry
+
+
+def publish(registry: Path, skill: Path, tags=None, force=False, as_json=False):
+    args = argparse.Namespace(
+        registry=str(registry), skill_path=str(skill),
+        tags=tags, force=force, json=as_json,
+    )
+    reg.cmd_publish(args)
+
+
+def read_registry(registry: Path) -> dict:
+    return json.loads((registry / "registry.json").read_text(encoding="utf-8"))
+
+
+# --- Pure helpers ---------------------------------------------------------
+
+class TestParseIsoDate(unittest.TestCase):
+    def test_plain_date(self):
+        self.assertEqual(reg.parse_iso_date("2026-06-13"), date(2026, 6, 13))
+
+    def test_full_iso_timestamp(self):
+        self.assertEqual(
+            reg.parse_iso_date("2026-06-13T12:30:00+00:00"), date(2026, 6, 13)
+        )
+
+    def test_empty_and_garbage_return_none(self):
+        self.assertIsNone(reg.parse_iso_date(""))
+        self.assertIsNone(reg.parse_iso_date("not-a-date"))
+        self.assertIsNone(reg.parse_iso_date("2026-13-99"))
+
+
+class TestStoragePath(unittest.TestCase):
+    def test_author_namespaced(self):
+        self.assertEqual(reg.skill_storage_path("foo", "Alice Doe"), "skills/alice-doe/foo")
+
+    def test_authorless_is_flat_legacy_layout(self):
+        self.assertEqual(reg.skill_storage_path("foo", ""), "skills/foo")
+
+
+# --- Publish --------------------------------------------------------------
+
+class TestPublish(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self.registry = init_registry(self.base)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_publish_creates_entry_and_files(self):
+        skill = make_skill(self.base, "alpha", author="alice")
+        publish(self.registry, skill)
+        data = read_registry(self.registry)
+        self.assertEqual(len(data["skills"]), 1)
+        entry = data["skills"][0]
+        self.assertEqual(entry["name"], "alpha")
+        self.assertEqual(entry["author"], "alice")
+        self.assertEqual(entry["path"], "skills/alice/alpha")
+        self.assertTrue((self.registry / "skills" / "alice" / "alpha" / "SKILL.md").exists())
+
+    def test_duplicate_same_author_version_blocked(self):
+        skill = make_skill(self.base, "alpha", author="alice")
+        publish(self.registry, skill)
+        with self.assertRaises(SystemExit):
+            publish(self.registry, skill)
+
+    def test_duplicate_overwritten_with_force(self):
+        skill = make_skill(self.base, "alpha", author="alice")
+        publish(self.registry, skill)
+        publish(self.registry, skill, force=True)
+        data = read_registry(self.registry)
+        self.assertEqual(len(data["skills"]), 1)
+
+    def test_invalid_skill_fails_validation(self):
+        bad = self.base / "bad-skill"
+        bad.mkdir()
+        # No SKILL.md -> validate_skill reports errors -> publish exits 1.
+        args = argparse.Namespace(
+            registry=str(self.registry), skill_path=str(bad),
+            tags=None, force=False, json=False,
+        )
+        with self.assertRaises(SystemExit):
+            reg.cmd_publish(args)
+
+
+# --- Author / namespace isolation -----------------------------------------
+
+class TestNamespaceIsolation(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self.registry = init_registry(self.base)
+        publish(self.registry, make_skill(self.base, "shared", author="alice"))
+        publish(self.registry, make_skill(self.base, "shared", author="bob"))
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_both_authors_coexist_without_clobber(self):
+        data = read_registry(self.registry)
+        self.assertEqual(len(data["skills"]), 2)
+        paths = {s["path"] for s in data["skills"]}
+        self.assertEqual(paths, {"skills/alice/shared", "skills/bob/shared"})
+        self.assertTrue((self.registry / "skills" / "alice" / "shared" / "SKILL.md").exists())
+        self.assertTrue((self.registry / "skills" / "bob" / "shared" / "SKILL.md").exists())
+
+    def test_resolve_ambiguous_name_requires_author(self):
+        data = read_registry(self.registry)
+        entry, error = reg.resolve_skill_entry(data, "shared")
+        self.assertIsNone(entry)
+        self.assertIn("multiple authors", error)
+
+    def test_resolve_with_author_disambiguates(self):
+        data = read_registry(self.registry)
+        entry, error = reg.resolve_skill_entry(data, "shared", "bob")
+        self.assertIsNone(error)
+        self.assertEqual(entry["author"], "bob")
+
+    def test_remove_only_targets_named_author(self):
+        args = argparse.Namespace(
+            registry=str(self.registry), skill_name="shared",
+            author="alice", force=True,
+        )
+        reg.cmd_remove(args)
+        data = read_registry(self.registry)
+        self.assertEqual([s["author"] for s in data["skills"]], ["bob"])
+        # alice's files gone, bob's intact
+        self.assertFalse((self.registry / "skills" / "alice" / "shared").exists())
+        self.assertTrue((self.registry / "skills" / "bob" / "shared").exists())
+
+
+# --- Search ---------------------------------------------------------------
+
+class TestSearch(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self.registry = init_registry(self.base)
+        publish(self.registry, make_skill(self.base, "weather-report", author="alice"))
+        publish(self.registry, make_skill(self.base, "crop-yield", author="bob"))
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_search_matches_name(self):
+        args = argparse.Namespace(registry=str(self.registry), query="weather", json=True)
+        # cmd_search prints JSON; capture stdout.
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            reg.cmd_search(args)
+        matches = json.loads(buf.getvalue())
+        self.assertEqual([m["name"] for m in matches], ["weather-report"])
+
+    def test_search_no_match(self):
+        args = argparse.Namespace(registry=str(self.registry), query="nonexistent", json=True)
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            reg.cmd_search(args)
+        self.assertEqual(json.loads(buf.getvalue()), [])
+
+
+# --- Install (platform + path resolution) ---------------------------------
+
+class TestResolveInstallPath(unittest.TestCase):
+    def test_user_path_for_known_platform(self):
+        path = reg.resolve_install_path("demo", "claude-code", project=False)
+        self.assertTrue(str(path).endswith("/.claude/skills/demo"))
+
+    def test_project_path_for_known_platform(self):
+        path = reg.resolve_install_path("demo", "claude-code", project=True)
+        self.assertTrue(str(path).endswith("/.claude/skills/demo"))
+
+    def test_unknown_platform_exits(self):
+        with self.assertRaises(SystemExit):
+            reg.resolve_install_path("demo", "nope", project=False)
+
+
+class TestInstall(unittest.TestCase):
+    def setUp(self):
+        self._cwd = os.getcwd()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self.registry = init_registry(self.base)
+        publish(self.registry, make_skill(self.base, "tool", author="alice"))
+        # Project-level installs resolve against cwd; chdir into an isolated dir.
+        self.workdir = self.base / "work"
+        self.workdir.mkdir()
+        os.chdir(self.workdir)
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+        self._tmp.cleanup()
+
+    def test_project_install_lands_at_resolved_path(self):
+        args = argparse.Namespace(
+            registry=str(self.registry), skill_name="tool", author=None,
+            platform="claude-code", project=True, force=False, json=False,
+        )
+        reg.cmd_install(args)
+        installed = self.workdir / ".claude" / "skills" / "tool" / "SKILL.md"
+        self.assertTrue(installed.exists())
+
+    def test_install_missing_skill_exits(self):
+        args = argparse.Namespace(
+            registry=str(self.registry), skill_name="ghost", author=None,
+            platform="claude-code", project=True, force=False, json=False,
+        )
+        with self.assertRaises(SystemExit):
+            reg.cmd_install(args)
+
+
+# --- Stale ----------------------------------------------------------------
+
+class TestStale(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self.registry = init_registry(self.base)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _run_stale(self):
+        import io
+        from contextlib import redirect_stdout
+        args = argparse.Namespace(registry=str(self.registry), json=True)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            reg.cmd_stale(args)
+        return json.loads(buf.getvalue())
+
+    def test_fresh_skill_from_published_timestamp(self):
+        publish(self.registry, make_skill(self.base, "fresh", author="alice"))
+        results = self._run_stale()
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["status"], "fresh")
+        self.assertEqual(results[0]["date_source"], "published")
+
+    def test_last_reviewed_overdue(self):
+        publish(self.registry, make_skill(self.base, "old", author="alice"))
+        # Inject an old last_reviewed date directly into the manifest.
+        data = read_registry(self.registry)
+        long_ago = (date.today() - timedelta(days=999)).isoformat()
+        data["skills"][0]["staleness"] = {
+            "last_reviewed": long_ago, "review_interval_days": 90,
+        }
+        (self.registry / "registry.json").write_text(
+            json.dumps(data, indent=2) + "\n", encoding="utf-8"
+        )
+        results = self._run_stale()
+        self.assertEqual(results[0]["status"], "overdue")
+        self.assertEqual(results[0]["date_source"], "last_reviewed")
+
+    def test_unparseable_date_is_unknown(self):
+        publish(self.registry, make_skill(self.base, "weird", author="alice"))
+        data = read_registry(self.registry)
+        data["skills"][0]["published"] = "not-a-date"
+        data["skills"][0]["staleness"] = {}
+        (self.registry / "registry.json").write_text(
+            json.dumps(data, indent=2) + "\n", encoding="utf-8"
+        )
+        results = self._run_stale()
+        self.assertEqual(results[0]["status"], "unknown")
+        self.assertEqual(results[0]["date_source"], "none")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_skill_registry.py
+++ b/scripts/tests/test_skill_registry.py
@@ -231,11 +231,12 @@ class TestSearch(unittest.TestCase):
 class TestResolveInstallPath(unittest.TestCase):
     def test_user_path_for_known_platform(self):
         path = reg.resolve_install_path("demo", "claude-code", project=False)
-        self.assertTrue(str(path).endswith("/.claude/skills/demo"))
+        # as_posix() normalizes separators so the assertion holds on Windows too.
+        self.assertTrue(path.as_posix().endswith("/.claude/skills/demo"))
 
     def test_project_path_for_known_platform(self):
         path = reg.resolve_install_path("demo", "claude-code", project=True)
-        self.assertTrue(str(path).endswith("/.claude/skills/demo"))
+        self.assertTrue(path.as_posix().endswith("/.claude/skills/demo"))
 
     def test_unknown_platform_exits(self):
         with self.assertRaises(SystemExit):


### PR DESCRIPTION
Closes #10, #11, #12 — all three deferred from the 2026-06 flaw-fix pass.

## #12 — Broaden hardcoded-secret detection
Adds detection for modern token formats, each with a concatenation-built test (the test file never contains a contiguous token-shaped string):
- Anthropic (`sk-ant-`), Stripe (`sk_live_`/`rk_live_`), npm (`npm_`), Google (`AIza…`), Hugging Face (`hf_`), generic JWT shape (medium severity).

## #11 — `--strict` flag for export
- `export_skill(..., strict=True)` and CLI `--strict` fail the export on any **high-severity** security finding.
- Default behavior unchanged: findings are reported but don't block.

## #10 — Test harness + author/namespace isolation for `skill_registry.py`
- **New test file** `scripts/tests/test_skill_registry.py`: publish (validation gating + dedup), install (platform/path resolution), search, stale, namespace isolation.
- **Date parsing:** replaced naive `published[:10].split('-')` slicing + silent `except` with `datetime.fromisoformat()` via a `parse_iso_date()` helper, pinned by tests.
- **Namespace isolation:** skill identity is now `(name, author, version)`. Files are stored under `skills/<author-slug>/<name>` so two authors can't clobber each other. `install`/`info`/`remove` gain `--author` to disambiguate a shared name.
- **Migration:** authorless entries keep the legacy flat `skills/<name>` layout and the per-entry stored `path`, so existing registries load and install unchanged — no destructive migration.

## Tests
- 187 pass (was 153, +34). `ruff check scripts/` clean.

## Loss function (binary checks, all met)
- #12: each new pattern detected on a fake token ✅; each has a concatenation test ✅; benign `os.environ[...]` stays clean ✅
- #11: strict blocks on high-severity ✅; default doesn't block ✅; CLI flag wired ✅
- #10: publish/install/search/stale covered ✅; ISO date parsing pinned ✅; two authors coexist ✅; legacy registries still load ✅